### PR TITLE
Install just in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.13-slim-bookworm
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     apt-get update && \
     apt-get install -y --no-install-recommends \
+        ca-certificates curl \
         # required by PostGIS
         gdal-bin
 
@@ -21,6 +22,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-install-project
+
+ENV JUST_VERSION=1.41.0
+ENV JUST_INSTALLER_URL="https://raw.githubusercontent.com/casey/just/3884a4e68395b46c4b3eed694b09955f65b79fcc/www/install.sh"
+ADD --checksum=sha256:2f811850e7833bf2191df55683f861d09b8a9cd2d1aac5f2adff597b3d675aa4 ${JUST_INSTALLER_URL} install.sh
+RUN chmod +x install.sh && ./install.sh --tag ${JUST_VERSION} --to /usr/local/bin
+RUN just --completions bash > ~/.bashrc
 
 COPY entrypoint.sh .
 


### PR DESCRIPTION
Coming from https://github.com/Mitchina/django_birthday_map/pull/8#pullrequestreview-2952983215

I found a simpler & cleaner solution to handle the installation while still validating the checksum. I believe this approach will be more helpful once when we moved the data operations to a Django management command from the current entrypoint.

I'd like to merge this soon if there is no important technical objection.